### PR TITLE
fix: lib std::filesystem introuvable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ IF (CMAKE_SYSTEM_NAME MATCHES "Linux")
     find_package(CURL REQUIRED) # Add this line to find cURL
 
     include_directories(${SDL2_INCLUDE_DIRS})
-    target_link_libraries(PaxOS8 PUBLIC -lpthread ${SDL2_LIBRARIES} CURL::libcurl) # Link to cURL
+    target_link_libraries(PaxOS8 PUBLIC -lpthread ${SDL2_LIBRARIES} CURL::libcurl -lstdc++fs) # Link to cURL
 
     target_link_libraries(PaxOS8 PRIVATE m)
 ELSEIF (CMAKE_SYSTEM_NAME MATCHES "Windows")


### PR DESCRIPTION
### Problème
Lors du build après un git clone, une erreur survient disant que la lib `std::filesystem` est introubable.

### Solution
Ce fix corrige le problème en ajoutant l'option `-lstdc++fs` dans le fichier [CMakeLists.txt](https://github.com/paxo-phone/PaxOS-8/blob/2cb4215df9f4c6d216b2fb888f8bb572bcd4ad54/CMakeLists.txt#L55).

### Captures d'écran
[Capture 1](https://github.com/paxo-phone/PaxOS-8/assets/19912551/73747439-48bf-4b7c-afa8-2355f8073c8f)

### Configuration

- Ubunutu 18.04
- g++ 8.4.0
- STD 17